### PR TITLE
Allow metaboxes to be attached to all taxonomies

### DIFF
--- a/includes/CMB2_Taxonomy.php
+++ b/includes/CMB2_Taxonomy.php
@@ -25,7 +25,7 @@ class CMB2_Taxonomy {
             return;
         }
 
-        $taxonomies = get_taxonomies(array('public' => true), 'names');
+        $taxonomies = get_taxonomies(null, 'names');
 
         foreach($taxonomies as $taxonomy_name) {
             add_action( "{$taxonomy_name}_add_form_fields", array($this, 'render_meta_fields_add_form'), 10);


### PR DESCRIPTION
I don't think the `array('public' => true)` rule is required, is it?